### PR TITLE
Fix/linter changes

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,3 @@
+env:
+  node: true
+  es6: true

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -227,7 +227,7 @@ rules:
 
   # Rule no-url-protocols will enforce that protocols and domains are not used within urls.
   # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-url-protocols.md
-  no-url-protocols: 2
+  no-url-protocols: 1
 
   # Rule no-vendor-prefixes will enforce that vendor prefixes are not allowed to be used.
   # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-vendor-prefixes.md

--- a/stylesheets/components/type/_type.scss
+++ b/stylesheets/components/type/_type.scss
@@ -1,1 +1,1 @@
-@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600');
+@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600");


### PR DESCRIPTION
Sets the eslint environment to node and enables es6.

Sets the sass-lint to allow external domains and protocols as we need to load google fonts. We keep the warning for now.