### PR TITLE
Adds a documentation page about service language

### DIFF
--- a/documentation/02-service-language.md
+++ b/documentation/02-service-language.md
@@ -1,0 +1,18 @@
+**Report management informaiton**
+
+**Report no business**  
+Previously refered to as a 'nil return'.
+
+**Supplier**
+
+**Customer**
+
+**Task**
+
+**Submission**
+
+**Supplier user**
+
+**CCS user**
+
+**Validation**


### PR DESCRIPTION
We wanted a way to document changes or decisions about language
in the service. We decided the styleguide was a good place to
store these docs.

The content will need fleshing out, but we add the page now.